### PR TITLE
Buffered requests

### DIFF
--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -12,14 +12,20 @@ import Raven
 class AppDelegate: UIResponder, UIApplicationDelegate {
                             
     var window: UIWindow?
-
+    
+    var ravenBuffer = UrlRequestBuffer()
+    var ravenBufferFlushTask: UIBackgroundTaskIdentifier?
+    
+    static let FlushRavenBufferTaskIdentifier = "co.calendre.flush-raven-buffer-task"
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
       
         RavenClient.clientWithDSN("https://663998f40e734ea59087883feda37647:306481b9f6bb4a6287b334178d9f8c71@app.getsentry.com/4394")
-        
+
         RavenClient.sharedClient?.setupExceptionHandler()
+        
+        RavenClient.sharedClient?.transportDelegate = ravenBuffer
 
         return true
     }
@@ -30,8 +36,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationDidEnterBackground(application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+        flushRavenBuffer(withApplication: application)
     }
 
     func applicationWillEnterForeground(application: UIApplication) {
@@ -43,9 +48,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillTerminate(application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+        flushRavenBuffer(withApplication: application)
     }
-
-
+    
+    func flushRavenBuffer(withApplication application: UIApplication) {
+        ravenBufferFlushTask = application.beginBackgroundTaskWithName(AppDelegate.FlushRavenBufferTaskIdentifier, expirationHandler: nil)
+        ravenBuffer.flushBuffer() {
+            precondition(self.ravenBufferFlushTask != nil)
+            application.endBackgroundTask(self.ravenBufferFlushTask!)
+        }
+    }
 }
-

--- a/Example/UrlRequestBuffer.swift
+++ b/Example/UrlRequestBuffer.swift
@@ -1,0 +1,71 @@
+//
+//  UrlRequestBuffer.swift
+//  Raven-Swift
+//
+//  Created by Joshua Fisher on 3/31/16.
+//  Copyright © 2016 OKB. All rights reserved.
+//
+
+import Foundation
+import Raven
+
+class UrlRequestBuffer {
+    
+    let session = NSURLSession(configuration: NSURLSessionConfiguration.defaultSessionConfiguration())
+    
+    private var requestBuffer: [NSURLRequest] = []
+    private let internalQueue = dispatch_queue_create("co.calendre.sentry-request-flush-queue", DISPATCH_QUEUE_SERIAL)
+    
+    func addRequest(request: NSURLRequest) {
+        dispatch_async(internalQueue) {
+            self.requestBuffer.append(request)
+        }
+    }
+    
+    func flushBuffer(withCompetionHandler completionHandler: () -> Void) {
+        dispatch_async(internalQueue) {
+            // grab all the requests
+            let requests = self.cycleRequestBuffer()
+            
+            // use dispatch group to wait for all the tasks to complete
+            let group = dispatch_group_create()
+            
+            // fire up tasks for all pending requests
+            for request in requests {
+                let task = self.session.dataTaskWithRequest(request) { (_, response, error) in
+                    dispatch_group_leave(group)
+                    
+                    if let error = error {
+                        let userInfo = error.userInfo as! [String: AnyObject]
+                        let errorKey: AnyObject? = userInfo[NSURLErrorFailingURLStringErrorKey]
+                        print("Connection failed! Error - \(error.localizedDescription) \(errorKey!)")
+                        
+                    } else if let response = response {
+                        #if DEBUG
+                            print("Response from Sentry: \(response)")
+                        #endif
+                    }
+                    print("JSON sent to Sentry")
+                }
+                dispatch_group_enter(group)
+                task.resume()
+            }
+            
+            // wait for all the requests to finish
+            dispatch_group_wait(group, DISPATCH_TIME_FOREVER)
+            completionHandler()
+        }
+    }
+    
+    private func cycleRequestBuffer() -> [NSURLRequest] {
+        let copy = requestBuffer
+        requestBuffer = []
+        return copy
+    }
+}
+
+extension UrlRequestBuffer: RavenClientTransportDelegate {
+    func ravenClient(client: RavenClient, producedRequest request: NSURLRequest) {
+        addRequest(request)
+    }
+}

--- a/Raven-Swift.xcodeproj/project.pbxproj
+++ b/Raven-Swift.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		030E0EA71A89D7D600E5E6BE /* Raven-OSX.h in Headers */ = {isa = PBXBuildFile; fileRef = 030E0EA11A89D4EA00E5E6BE /* Raven-OSX.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03DE86181A89D9060056F441 /* Raven.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 030E0E751A89D34D00E5E6BE /* Raven.framework */; };
 		03DE86191A89D9060056F441 /* Raven.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 030E0E751A89D34D00E5E6BE /* Raven.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		03F62EFB1CADAB1D00ED896D /* UrlRequestBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F62EFA1CADAB1D00ED896D /* UrlRequestBuffer.swift */; };
 		63A8B07F1C335347003A99FF /* RavenConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650712C719BB1E7B00786DC4 /* RavenConfig.swift */; };
 		63A8B0801C335347003A99FF /* UncaughtExceptionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 650712C419BB16A500786DC4 /* UncaughtExceptionHandler.m */; };
 		63A8B0811C335347003A99FF /* RavenClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650712C619BB1E7B00786DC4 /* RavenClient.swift */; };
@@ -75,6 +76,7 @@
 		030E0EA01A89D4EA00E5E6BE /* Raven-iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Raven-iOS.h"; sourceTree = "<group>"; };
 		030E0EA11A89D4EA00E5E6BE /* Raven-OSX.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Raven-OSX.h"; sourceTree = "<group>"; };
 		030E0EA21A89D59C00E5E6BE /* Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Bridging-Header.h"; sourceTree = "<group>"; };
+		03F62EFA1CADAB1D00ED896D /* UrlRequestBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UrlRequestBuffer.swift; sourceTree = "<group>"; };
 		63A8B08B1C335347003A99FF /* Raven.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Raven.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		63A8B08C1C335347003A99FF /* Info-tvOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Info-tvOS.plist"; path = "/Users/david/Code/raven-swift/Info-tvOS.plist"; sourceTree = "<absolute>"; };
 		650712C319BB16A500786DC4 /* UncaughtExceptionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UncaughtExceptionHandler.h; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 			children = (
 				650712CA19BB1E8700786DC4 /* AppDelegate.swift */,
 				650712CB19BB1E8700786DC4 /* ViewController.swift */,
+				03F62EFA1CADAB1D00ED896D /* UrlRequestBuffer.swift */,
 				652C5DEB19B7AA2D002CD4A9 /* Main.storyboard */,
 				652C5DEE19B7AA2D002CD4A9 /* Images.xcassets */,
 				652C5DE519B7AA2C002CD4A9 /* Supporting Files */,
@@ -471,6 +474,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				650712CD19BB1E8700786DC4 /* ViewController.swift in Sources */,
+				03F62EFB1CADAB1D00ED896D /* UrlRequestBuffer.swift in Sources */,
 				650712CC19BB1E8700786DC4 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Raven-Swift.xcodeproj/xcshareddata/xcschemes/Raven-tvOS.xcscheme
+++ b/Raven-Swift.xcodeproj/xcshareddata/xcschemes/Raven-tvOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "63A8B07D1C335347003A99FF"
-               BuildableName = "Raven-tvOS.framework"
+               BuildableName = "Raven.framework"
                BlueprintName = "Raven-tvOS"
                ReferencedContainer = "container:Raven-Swift.xcodeproj">
             </BuildableReference>
@@ -46,7 +46,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "63A8B07D1C335347003A99FF"
-            BuildableName = "Raven-tvOS.framework"
+            BuildableName = "Raven.framework"
             BlueprintName = "Raven-tvOS"
             ReferencedContainer = "container:Raven-Swift.xcodeproj">
          </BuildableReference>
@@ -64,7 +64,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "63A8B07D1C335347003A99FF"
-            BuildableName = "Raven-tvOS.framework"
+            BuildableName = "Raven.framework"
             BlueprintName = "Raven-tvOS"
             ReferencedContainer = "container:Raven-Swift.xcodeproj">
          </BuildableReference>

--- a/Raven/RavenClient.swift
+++ b/Raven/RavenClient.swift
@@ -181,7 +181,7 @@ public class RavenClient : NSObject {
 
     :param: message  The message to be logged
     */
-    public func captureMessage(message : String, method: String? = __FUNCTION__ , file: String? = __FILE__, line: Int = __LINE__) {
+    public func captureMessage(message : String, method: String? = #function , file: String? = #file, line: Int = #line) {
         self.captureMessage(message, level: .Info, additionalExtra:[:], additionalTags:[:], method:method, file:file, line:line)
     }
 
@@ -192,7 +192,7 @@ public class RavenClient : NSObject {
     :param: message  The message to be logged
     :param: level  log level
     */
-    public func captureMessage(message: String, level: RavenLogLevel, method: String? = __FUNCTION__ , file: String? = __FILE__, line: Int = __LINE__){
+    public func captureMessage(message: String, level: RavenLogLevel, method: String? = #function , file: String? = #file, line: Int = #line){
         self.captureMessage(message, level: level, additionalExtra:[:], additionalTags:[:], method:method, file:file, line:line)
     }
 
@@ -205,7 +205,7 @@ public class RavenClient : NSObject {
     :param: additionalExtra  Additional data that will be sent with the log
     :param: additionalTags  Additional tags that will be sent with the log
     */
-    public func captureMessage(message: String, level: RavenLogLevel, additionalExtra:[String: AnyObject], additionalTags: [String: AnyObject], method:String? = __FUNCTION__, file:String? = __FILE__, line:Int = __LINE__) {
+    public func captureMessage(message: String, level: RavenLogLevel, additionalExtra:[String: AnyObject], additionalTags: [String: AnyObject], method:String? = #function, file:String? = #file, line:Int = #line) {
         var stacktrace : [AnyObject] = []
         var culprit : String = ""
 
@@ -229,7 +229,7 @@ public class RavenClient : NSObject {
 
     :param: error  The error to capture
     */
-    public func captureError(error : NSError, method: String? = __FUNCTION__, file: String? = __FILE__, line: Int = __LINE__) {
+    public func captureError(error : NSError, method: String? = #function, file: String? = #file, line: Int = #line) {
         self.captureMessage("\(error)", level: .Error, method: method, file: file, line: line )
     }
 
@@ -241,7 +241,7 @@ public class RavenClient : NSObject {
 
     :param: error  The error to capture
     */
-    public func captureError<E where E:ErrorType, E:StringLiteralConvertible>(error: E, method: String? = __FUNCTION__, file: String? = __FILE__, line: Int = __LINE__) {
+    public func captureError<E where E:ErrorType, E:StringLiteralConvertible>(error: E, method: String? = #function, file: String? = #file, line: Int = #line) {
         self.captureMessage("\(error)", level: .Error, method: method, file: file, line: line )
     }
 
@@ -320,7 +320,7 @@ public class RavenClient : NSObject {
     :param: exception  The exception to be captured.
     :param: sendNow  Control whether the exception is sent to the server now, or when the app is next opened
     */
-    public func captureException(exception: NSException, method:String? = __FUNCTION__, file:String? = __FILE__, line:Int = __LINE__, sendNow:Bool = false) {
+    public func captureException(exception: NSException, method:String? = #function, file:String? = #file, line:Int = #line, sendNow:Bool = false) {
         let message = "\(exception.name): \(exception.reason!)"
         let exceptionDict = ["type": exception.name, "value": exception.reason ?? ""]
 

--- a/Raven/RavenConfig.swift
+++ b/Raven/RavenConfig.swift
@@ -14,51 +14,44 @@ public class RavenConfig {
     let projectId: String!
     
     public init? (DSN : String) {
-        if let DSNURL = NSURL(string: DSN), host = DSNURL.host {
-            var pathComponents = DSNURL.pathComponents!
-            
-            pathComponents.removeAtIndex(0) // always remove the first slash
-            
-            if let projectId = pathComponents.last {
-                self.projectId = projectId
-                
-                pathComponents.removeLast() // remove the project id...
-                
-                var path = pathComponents.joinWithSeparator("/")  // ...and construct the path again
-                
-                // Add a slash to the end of the path if there is a path
-                if (path != "") {
-                    path += "/"
-                }
-                
-                let scheme: String = DSNURL.scheme ?? "http"
-                
-                var port = DSNURL.port
-                if (port == nil) {
-                    if (DSNURL.scheme == "https") {
-                        port = 443;
-                    } else {
-                        port = 80;
-                    }
-                }
-                
-                //Setup the URL
-                serverUrl = NSURL(string: "\(scheme)://\(host):\(port!)\(path)/api/\(projectId)/store/")
-                
-                //Set the public and secret keys if the exist
-                publicKey = DSNURL.user ?? ""
-                secretKey = DSNURL.password ?? ""
-                
-                return
+        guard let DSNURL = NSURL(string: DSN), host = DSNURL.host else {
+            return nil
+        }
+        
+        var pathComponents = DSNURL.pathComponents!
+        
+        pathComponents.removeAtIndex(0) // always remove the first slash
+        
+        guard let projectId = pathComponents.last else {
+            return nil
+        }
+        self.projectId = projectId
+        
+        pathComponents.removeLast() // remove the project id...
+        
+        var path = pathComponents.joinWithSeparator("/")  // ...and construct the path again
+        
+        // Add a slash to the end of the path if there is a path
+        if (path != "") {
+            path += "/"
+        }
+        
+        let scheme: String = DSNURL.scheme ?? "http"
+        
+        var port = DSNURL.port
+        if (port == nil) {
+            if (DSNURL.scheme == "https") {
+                port = 443;
+            } else {
+                port = 80;
             }
         }
         
-        //The URL couldn't be parsed, so initialize to blank values and return nil
-        serverUrl = NSURL()
-        publicKey = ""
-        secretKey = ""
-        projectId = ""
+        //Setup the URL
+        serverUrl = NSURL(string: "\(scheme)://\(host):\(port!)\(path)/api/\(projectId)/store/")
         
-        return nil
+        //Set the public and secret keys if the exist
+        publicKey = DSNURL.user ?? ""
+        secretKey = DSNURL.password ?? ""
     }
 }


### PR DESCRIPTION
tries to flush a buffer of `NSURLRequest` on background & terminate. i could add writing the buffered requests to disk in the case where the background task runs out of time or is is killed. raven doesn't play nice with `Crashlytics`, which is a bummer & will prevent reporting crashing issues to sentry. i could work around it, depends on how thorough we want to be
